### PR TITLE
Implement CREATE, UPDATE and DELETE features

### DIFF
--- a/docs/resources/Entity.md
+++ b/docs/resources/Entity.md
@@ -1,4 +1,5 @@
 [http-get]: https://img.shields.io/badge/GET-505CDC
+[http-delete]: https://img.shields.io/badge/DELETE-A12828
 
 # Entity resource
 
@@ -24,3 +25,6 @@ Returns a list of all known entity ids.
 ## Get user</br>![http-get] /entities/[{entity.id}](#entity-object)
 Returns a single [entity](#entity-object) object.
 If no entity with the specified id exists this will return `204 No Content`.
+
+## Remove permission override</br>![http-delete] /entities/[{entity.id}](#entity-object)/[{permission.name}](#permission-structure)
+Removes a permission override from an entity. Returns `204 No Content` on success.

--- a/docs/resources/Entity.md
+++ b/docs/resources/Entity.md
@@ -1,4 +1,5 @@
 [http-get]: https://img.shields.io/badge/GET-505CDC
+[http-put]: https://img.shields.io/badge/PUT-AC5A1F
 [http-delete]: https://img.shields.io/badge/DELETE-A12828
 
 # Entity resource
@@ -26,5 +27,14 @@ Returns a list of all known entity ids.
 Returns a single [entity](#entity-object) object.
 If no entity with the specified id exists this will return `204 No Content`.
 
+## Set permission override</br>![http-put] /entities/[{entity.id}](#entity-object)/[{permission.name}](#permission-structure)
+Creates or updates a permission override of an entity.
+Returns `204 No Content` on success.
+
+| Parameter | Type | Description               |
+|-----------|------|---------------------------|
+| value     | bool | Permission override value |
+
 ## Remove permission override</br>![http-delete] /entities/[{entity.id}](#entity-object)/[{permission.name}](#permission-structure)
-Removes a permission override from an entity. Returns `204 No Content` on success.
+Removes a permission override from an entity.
+Returns `204 No Content` on success.

--- a/src/main/java/org/burrow_studios/gatekeeper/database/Database.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/database/Database.java
@@ -18,6 +18,8 @@ public class Database {
     private static final String STMT_GET_ENTITIES = "SELECT DISTINCT `entity_id` AS `id` FROM `entity_permissions`;";
     private static final String STMT_GET_ENTITY = "SELECT `permissions`.`name` AS `permission`, `entity_permissions`.`value` FROM `entity_permissions` INNER JOIN `permissions` ON `entity_permissions`.`permission_id` = `permissions`.`id` WHERE `entity_permissions`.`entity_id` = ? ORDER BY `permissions`.`name`;";
 
+    private static final String STMT_DELETE_PERMISSION = "DELETE FROM `entity_permissions` WHERE `entity_id` = ? AND `permission_id` = (SELECT `id` FROM `permissions` WHERE `name` = '?');";
+
     private static final Logger LOG = Logger.getLogger(Database.class.getSimpleName());
 
     private final Connection connection;
@@ -98,6 +100,15 @@ public class Database {
             entity.add("overrides", overrides);
 
             return entity;
+        }
+    }
+
+    public void removePermission(long id, String permission) throws SQLException {
+        try (PreparedStatement stmt = connection.prepareStatement(STMT_DELETE_PERMISSION)) {
+            stmt.setLong(1, id);
+            stmt.setString(2, permission);
+
+            stmt.execute();
         }
     }
 

--- a/src/main/java/org/burrow_studios/gatekeeper/database/Database.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/database/Database.java
@@ -18,10 +18,10 @@ public class Database {
     private static final String STMT_GET_ENTITIES = "SELECT DISTINCT `entity_id` AS `id` FROM `entity_permissions`;";
     private static final String STMT_GET_ENTITY = "SELECT `permissions`.`name` AS `permission`, `entity_permissions`.`value` FROM `entity_permissions` INNER JOIN `permissions` ON `entity_permissions`.`permission_id` = `permissions`.`id` WHERE `entity_permissions`.`entity_id` = ? ORDER BY `permissions`.`name`;";
 
-    private static final String STMT_DELETE_PERMISSION = "DELETE FROM `entity_permissions` WHERE `entity_id` = ? AND `permission_id` = (SELECT `id` FROM `permissions` WHERE `name` = '?');";
+    private static final String STMT_DELETE_PERMISSION = "DELETE FROM `entity_permissions` WHERE `entity_id` = ? AND `permission_id` = (SELECT `id` FROM `permissions` WHERE `name` = ?);";
 
-    private static final String STMT_ADD_PERMISSION = "INSERT IGNORE INTO `permissions`(`name`) VALUES('?')";
-    private static final String STMT_SET_PERMISSION = "INSERT INTO `entity_permissions`(`entity_id`, `permission_id`, `value`) VALUES(?, (SELECT `id` FROM `permissions` WHERE `name` = '?'), ?) ON DUPLICATE KEY UPDATE `value` = ?;";
+    private static final String STMT_ADD_PERMISSION = "INSERT IGNORE INTO `permissions`(`name`) VALUES(?)";
+    private static final String STMT_SET_PERMISSION = "INSERT INTO `entity_permissions`(`entity_id`, `permission_id`, `value`) VALUES(?, (SELECT `id` FROM `permissions` WHERE `name` = ?), ?) ON DUPLICATE KEY UPDATE `value` = ?;";
 
     private static final Logger LOG = Logger.getLogger(Database.class.getSimpleName());
 

--- a/src/main/java/org/burrow_studios/gatekeeper/database/Database.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/database/Database.java
@@ -20,6 +20,9 @@ public class Database {
 
     private static final String STMT_DELETE_PERMISSION = "DELETE FROM `entity_permissions` WHERE `entity_id` = ? AND `permission_id` = (SELECT `id` FROM `permissions` WHERE `name` = '?');";
 
+    private static final String STMT_ADD_PERMISSION = "INSERT IGNORE INTO `permissions`(`name`) VALUES('?')";
+    private static final String STMT_SET_PERMISSION = "INSERT INTO `entity_permissions`(`entity_id`, `permission_id`, `value`) VALUES(?, (SELECT `id` FROM `permissions` WHERE `name` = '?'), ?) ON DUPLICATE KEY UPDATE `value` = ?;";
+
     private static final Logger LOG = Logger.getLogger(Database.class.getSimpleName());
 
     private final Connection connection;
@@ -107,6 +110,27 @@ public class Database {
         try (PreparedStatement stmt = connection.prepareStatement(STMT_DELETE_PERMISSION)) {
             stmt.setLong(1, id);
             stmt.setString(2, permission);
+
+            stmt.execute();
+        }
+    }
+
+    public void createPermission(String permission) throws SQLException {
+        try (PreparedStatement stmt = connection.prepareStatement(STMT_ADD_PERMISSION)) {
+            stmt.setString(1, permission);
+
+            stmt.execute();
+        }
+    }
+
+    public void setPermission(long id, String permission, boolean value) throws SQLException {
+        this.createPermission(permission);
+
+        try (PreparedStatement stmt = connection.prepareStatement(STMT_SET_PERMISSION)) {
+            stmt.setLong(1, id);
+            stmt.setString(2, permission);
+            stmt.setBoolean(3, value);
+            stmt.setBoolean(4, value);
 
             stmt.execute();
         }

--- a/src/main/java/org/burrow_studios/gatekeeper/net/Response.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/Response.java
@@ -1,7 +1,5 @@
 package org.burrow_studios.gatekeeper.net;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,11 +12,6 @@ public final class Response {
     public static final Response ERROR_METHOD_NOT_ALLOWED = new Response(405);
     public static final Response ERROR_INTERNAL_SERVER_ERROR = new Response(500);
     public static final Response ERROR_NOT_IMPLEMENTED = new Response(501);
-
-    private static final Gson gson = new GsonBuilder()
-            .setPrettyPrinting()
-            .serializeNulls()
-            .create();
 
     private final int code;
     private final byte[] body;
@@ -65,13 +58,13 @@ public final class Response {
     }
 
     public Response withBody(JsonElement json) {
-        return this.withBody(gson.toJson(json));
+        return this.withBody(Server.serializeJson(json));
     }
 
     /* - - - */
 
     public static Response ofJson(int code, JsonElement json) {
-        String contentString = gson.toJson(json);
+        String contentString = Server.serializeJson(json);
         Map<String, String> headers = Map.of("Content-Type", "application/json");
         return new Response(code, contentString.getBytes(), headers);
     }

--- a/src/main/java/org/burrow_studios/gatekeeper/net/Response.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/Response.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 public final class Response {
     public static final Response ERROR_BAD_REQUEST = new Response(400);
     public static final Response ERROR_NOT_FOUND = new Response(404);
+    public static final Response ERROR_METHOD_NOT_ALLOWED = new Response(405);
     public static final Response ERROR_INTERNAL_SERVER_ERROR = new Response(500);
     public static final Response ERROR_NOT_IMPLEMENTED = new Response(501);
 

--- a/src/main/java/org/burrow_studios/gatekeeper/net/RouteHandler.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/RouteHandler.java
@@ -30,7 +30,7 @@ public abstract class RouteHandler implements HttpHandler {
             requestMethod       = exchange.getRequestMethod();
             requestPath         = exchange.getRequestURI().getPath();
             requestPathSegments = requestPath.substring(1).split("/");
-            requestBody         = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_16);
+            requestBody         = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Encountered an exception when attempting to prepare a request", e);
             exchange.sendResponseHeaders(Response.ERROR_INTERNAL_SERVER_ERROR.getCode(), -1);

--- a/src/main/java/org/burrow_studios/gatekeeper/net/RouteHandler.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/RouteHandler.java
@@ -6,6 +6,7 @@ import org.burrow_studios.gatekeeper.database.Database;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,11 +24,13 @@ public abstract class RouteHandler implements HttpHandler {
         final String   requestMethod;
         final String   requestPath;
         final String[] requestPathSegments;
+        final String   requestBody;
 
         try {
             requestMethod       = exchange.getRequestMethod();
             requestPath         = exchange.getRequestURI().getPath();
             requestPathSegments = requestPath.substring(1).split("/");
+            requestBody         = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_16);
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Encountered an exception when attempting to prepare a request", e);
             exchange.sendResponseHeaders(Response.ERROR_INTERNAL_SERVER_ERROR.getCode(), -1);
@@ -36,7 +39,7 @@ public abstract class RouteHandler implements HttpHandler {
 
         LOG.log(Level.FINER, "Processing request " + requestMethod + " " + requestPath);
 
-        Response response = handle0(requestMethod, requestPath, requestPathSegments);
+        Response response = handle0(requestMethod, requestPath, requestPathSegments, requestBody);
 
         exchange.sendResponseHeaders(response.getCode(), response.getBodyLength());
         exchange.getResponseBody().write(response.getBody());
@@ -44,16 +47,16 @@ public abstract class RouteHandler implements HttpHandler {
         exchange.close();
     }
 
-    private @NotNull Response handle0(String method, String path, String[] pathSegments) {
+    private @NotNull Response handle0(String method, String path, String[] pathSegments, String content) {
         try {
-            return this.handle(method, path, pathSegments);
+            return this.handle(method, path, pathSegments, content);
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Encountered an exception when attempting to prepare a request", e);
             return Response.ERROR_INTERNAL_SERVER_ERROR;
         }
     }
 
-    public abstract @NotNull Response handle(String method, String path, String[] segments) throws Exception;
+    public abstract @NotNull Response handle(String method, String path, String[] segments, String content) throws Exception;
 
     protected @NotNull Database getDatabase() {
         return this.server.getGatekeeper().getDatabase();

--- a/src/main/java/org/burrow_studios/gatekeeper/net/Server.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/Server.java
@@ -1,5 +1,8 @@
 package org.burrow_studios.gatekeeper.net;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.sun.net.httpserver.HttpServer;
 import org.burrow_studios.gatekeeper.Gatekeeper;
 import org.burrow_studios.gatekeeper.net.handlers.EntityHandler;
@@ -13,6 +16,11 @@ import java.util.logging.Logger;
 
 public class Server {
     private static final Logger LOG = Logger.getLogger(Server.class.getSimpleName());
+
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .serializeNulls()
+            .create();
 
     private final Gatekeeper gatekeeper;
     private final HttpServer httpServer;
@@ -38,5 +46,13 @@ public class Server {
 
     public @NotNull Gatekeeper getGatekeeper() {
         return gatekeeper;
+    }
+
+    public static JsonElement deserializeJson(String rawJson) {
+        return GSON.fromJson(rawJson, JsonElement.class);
+    }
+
+    public static String serializeJson(JsonElement json) {
+        return GSON.toJson(json);
     }
 }

--- a/src/main/java/org/burrow_studios/gatekeeper/net/handlers/EntityHandler.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/handlers/EntityHandler.java
@@ -20,6 +20,8 @@ public class EntityHandler extends RouteHandler {
         if (segments.length == 1) {
             assert Objects.equals(segments[0], "entities");
 
+            if (!method.equals("GET"))
+                return Response.ERROR_METHOD_NOT_ALLOWED;
             return Response.ofJson(200, getDatabase().getEntities());
         }
 
@@ -31,6 +33,22 @@ public class EntityHandler extends RouteHandler {
         } catch (NumberFormatException e) {
             return Response.ERROR_BAD_REQUEST.withBody("Invalid id format".getBytes());
         }
+
+        if (segments.length == 3) {
+            String permission = segments[2];
+
+            if (!method.equals("DELETE"))
+                return Response.ERROR_METHOD_NOT_ALLOWED;
+
+            getDatabase().removePermission(id, permission);
+            return new Response(204);
+        }
+
+        if (segments.length < 3)
+            return Response.ERROR_NOT_FOUND;
+
+        if (!method.equals("GET"))
+            return Response.ERROR_METHOD_NOT_ALLOWED;
 
         JsonObject entity = getDatabase().getEntity(id);
 

--- a/src/main/java/org/burrow_studios/gatekeeper/net/handlers/EntityHandler.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/handlers/EntityHandler.java
@@ -58,7 +58,7 @@ public class EntityHandler extends RouteHandler {
             return Response.ERROR_METHOD_NOT_ALLOWED;
         }
 
-        if (segments.length < 3)
+        if (segments.length != 2)
             return Response.ERROR_NOT_FOUND;
 
         if (!method.equals("GET"))

--- a/src/main/java/org/burrow_studios/gatekeeper/net/handlers/EntityHandler.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/handlers/EntityHandler.java
@@ -1,5 +1,6 @@
 package org.burrow_studios.gatekeeper.net.handlers;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.burrow_studios.gatekeeper.net.Response;
 import org.burrow_studios.gatekeeper.net.RouteHandler;
@@ -14,7 +15,7 @@ public class EntityHandler extends RouteHandler {
     }
 
     @Override
-    public @NotNull Response handle(String method, String path, String[] segments) throws Exception {
+    public @NotNull Response handle(String method, String path, String[] segments, String content) throws Exception {
         assert segments.length > 0;
 
         if (segments.length == 1) {
@@ -37,11 +38,24 @@ public class EntityHandler extends RouteHandler {
         if (segments.length == 3) {
             String permission = segments[2];
 
-            if (!method.equals("DELETE"))
-                return Response.ERROR_METHOD_NOT_ALLOWED;
+            if (method.equals("DELETE")) {
+                getDatabase().removePermission(id, permission);
+                return new Response(204);
+            }
 
-            getDatabase().removePermission(id, permission);
-            return new Response(204);
+            if (method.equals("PUT")) {
+                JsonElement requestBody = Server.deserializeJson(content);
+
+                if (!(requestBody instanceof JsonObject json))
+                    return Response.ERROR_BAD_REQUEST;
+
+                boolean value = json.get("value").getAsBoolean();
+
+                getDatabase().setPermission(id, permission, value);
+                return new Response(204);
+            }
+
+            return Response.ERROR_METHOD_NOT_ALLOWED;
         }
 
         if (segments.length < 3)

--- a/src/main/java/org/burrow_studios/gatekeeper/net/handlers/NotFoundHandler.java
+++ b/src/main/java/org/burrow_studios/gatekeeper/net/handlers/NotFoundHandler.java
@@ -11,7 +11,7 @@ public class NotFoundHandler extends RouteHandler {
     }
 
     @Override
-    public @NotNull Response handle(String method, String path, String[] segments) {
+    public @NotNull Response handle(String method, String path, String[] segments, String content) {
         return Response.ERROR_NOT_FOUND;
     }
 }


### PR DESCRIPTION
Right now, the RESTful API can only be used to read data. Gatekeeper should however offer all CRUD operations.